### PR TITLE
Don't overwrite web dir with volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         volumes:
             - ./account-data:/opt/cloudmapper/account-data
             - ./config.json:/opt/cloudmapper/config.json
-            - ./web:/opt/cloudmapper/web
+            - ./web/data.json:/opt/cloudmapper/web/data.json
         ports:
             - ${EXTERNAL_PORT}:8000
         # TODO: switch to environment variables instead loading the .env manually


### PR DESCRIPTION
The existing volume mount was fully overwriting the directory,
meaning there were not assets for the web server to load other
than data.json.

Change the volume mount to specify the data.json file so the
container has access to both